### PR TITLE
Refactor logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ catkin_package(
 add_compile_options(-std=c++11)
 include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} include)
 
-add_executable(urg_stamped src/urg_stamped.cpp src/scip2/logger.cpp)
+add_executable(urg_stamped src/urg_stamped.cpp src/scip2/logger.cpp src/ros_logger.cpp)
 target_link_libraries(urg_stamped ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ catkin_package(
 add_compile_options(-std=c++11)
 include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} include)
 
-add_executable(urg_stamped src/urg_stamped.cpp)
+add_executable(urg_stamped src/urg_stamped.cpp src/scip2/logger.cpp)
 target_link_libraries(urg_stamped ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 

--- a/include/ros_logger.h
+++ b/include/ros_logger.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 The urg_stamped Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ROS_LOGGER_H
+#define ROS_LOGGER_H
+
+#include <iostream>
+
+namespace urg_stamped
+{
+void setROSLogger();
+}  // namespace urg_stamped
+
+#endif  // ROS_LOGGER_H

--- a/include/ros_logger.h
+++ b/include/ros_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The urg_stamped Authors
+ * Copyright 2019 The urg_stamped Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/scip2/connection.h
+++ b/include/scip2/connection.h
@@ -22,6 +22,8 @@
 
 #include <string>
 
+#include <scip2/logger.h>
+
 namespace scip2
 {
 class Protocol;
@@ -108,7 +110,7 @@ protected:
   {
     if (!error)
     {
-      std::cerr << "Watchdog timeout" << std::endl;
+      logger::fatal << "Watchdog timeout" << std::endl;
       close();
     }
   }
@@ -118,7 +120,7 @@ protected:
     const auto time_read = boost::posix_time::microsec_clock::universal_time();
     if (error)
     {
-      std::cerr << "Receive error" << std::endl;
+      logger::fatal << "Receive error" << std::endl;
       close();
       return;
     }
@@ -131,7 +133,7 @@ protected:
     const auto time_send = boost::posix_time::microsec_clock::universal_time();
     if (error)
     {
-      std::cerr << "Send error" << std::endl;
+      logger::fatal << "Send error" << std::endl;
       close();
       return;
     }
@@ -149,7 +151,7 @@ protected:
   {
     if (error)
     {
-      std::cerr << "Connection error" << std::endl;
+      logger::fatal << "Connection error" << std::endl;
       close();
       return;
     }
@@ -161,7 +163,7 @@ protected:
   {
     if (!error)
     {
-      std::cerr << "Connection timeout" << std::endl;
+      logger::fatal << "Connection timeout" << std::endl;
       close();
       return;
     }

--- a/include/scip2/connection.h
+++ b/include/scip2/connection.h
@@ -110,7 +110,7 @@ protected:
   {
     if (!error)
     {
-      logger::fatal << "Watchdog timeout" << std::endl;
+      logger::fatal() << "Watchdog timeout" << std::endl;
       close();
     }
   }
@@ -120,7 +120,7 @@ protected:
     const auto time_read = boost::posix_time::microsec_clock::universal_time();
     if (error)
     {
-      logger::fatal << "Receive error" << std::endl;
+      logger::fatal() << "Receive error" << std::endl;
       close();
       return;
     }
@@ -133,7 +133,7 @@ protected:
     const auto time_send = boost::posix_time::microsec_clock::universal_time();
     if (error)
     {
-      logger::fatal << "Send error" << std::endl;
+      logger::fatal() << "Send error" << std::endl;
       close();
       return;
     }
@@ -151,7 +151,7 @@ protected:
   {
     if (error)
     {
-      logger::fatal << "Connection error" << std::endl;
+      logger::fatal() << "Connection error" << std::endl;
       close();
       return;
     }
@@ -163,7 +163,7 @@ protected:
   {
     if (!error)
     {
-      logger::fatal << "Connection timeout" << std::endl;
+      logger::fatal() << "Connection timeout" << std::endl;
       close();
       return;
     }

--- a/include/scip2/logger.h
+++ b/include/scip2/logger.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 The urg_stamped Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SCIP2_LOGGER_H
+#define SCIP2_LOGGER_H
+
+#include <iostream>
+
+namespace scip2
+{
+namespace logger
+{
+extern std::ostream debug;
+extern std::ostream info;
+extern std::ostream warn;
+extern std::ostream error;
+extern std::ostream fatal;
+}  // namespace logger
+}  // namespace scip2
+
+#endif  // SCIP2_LOGGER_H

--- a/include/scip2/logger.h
+++ b/include/scip2/logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The urg_stamped Authors
+ * Copyright 2019 The urg_stamped Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/scip2/logger.h
+++ b/include/scip2/logger.h
@@ -23,11 +23,16 @@ namespace scip2
 {
 namespace logger
 {
-extern std::ostream debug;
-extern std::ostream info;
-extern std::ostream warn;
-extern std::ostream error;
-extern std::ostream fatal;
+void setDebugLogger(std::ostream *l);
+void setInfoLogger(std::ostream *l);
+void setWarnLogger(std::ostream *l);
+void setErrorLogger(std::ostream *l);
+void setFatalLogger(std::ostream *l);
+std::ostream &debug();
+std::ostream &info();
+std::ostream &warn();
+std::ostream &error();
+std::ostream &fatal();
 }  // namespace logger
 }  // namespace scip2
 

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -22,6 +22,7 @@
 
 #include <scip2/connection.h>
 #include <scip2/response.h>
+#include <scip2/logger.h>
 
 #include <map>
 #include <string>
@@ -42,13 +43,13 @@ protected:
     std::string echo_back;
     if (!std::getline(stream, echo_back))
     {
-      std::cerr << "Failed to get echo back" << std::endl;
+      logger::error << "Failed to get echo back" << std::endl;
       return;
     }
     std::string status;
     if (!std::getline(stream, status))
     {
-      std::cerr << "Failed to get status" << std::endl;
+      logger::error << "Failed to get status" << std::endl;
       return;
     }
     status.pop_back();  // remove checksum

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -43,13 +43,13 @@ protected:
     std::string echo_back;
     if (!std::getline(stream, echo_back))
     {
-      logger::error << "Failed to get echo back" << std::endl;
+      logger::error() << "Failed to get echo back" << std::endl;
       return;
     }
     std::string status;
     if (!std::getline(stream, status))
     {
-      logger::error << "Failed to get status" << std::endl;
+      logger::error() << "Failed to get status" << std::endl;
       return;
     }
     status.pop_back();  // remove checksum

--- a/include/scip2/response.h
+++ b/include/scip2/response.h
@@ -27,6 +27,7 @@
 #include <scip2/response/stream.h>
 #include <scip2/response/time_sync.h>
 #include <scip2/response/quit.h>
+#include <scip2/logger.h>
 
 namespace scip2
 {
@@ -60,7 +61,7 @@ public:
     const auto response = responses_.find(command_code);
     if (response == responses_.end())
     {
-      std::cerr << "Unknown response " << command_code << std::endl;
+      logger::info << "Unknown response " << command_code << std::endl;
       return;
     }
     (*(response->second))(time_read, echo_back, status, stream);

--- a/include/scip2/response.h
+++ b/include/scip2/response.h
@@ -61,7 +61,7 @@ public:
     const auto response = responses_.find(command_code);
     if (response == responses_.end())
     {
-      logger::info() << "Unknown response " << command_code << std::endl;
+      logger::debug() << "Unknown response " << command_code << std::endl;
       return;
     }
     (*(response->second))(time_read, echo_back, status, stream);

--- a/include/scip2/response.h
+++ b/include/scip2/response.h
@@ -61,7 +61,7 @@ public:
     const auto response = responses_.find(command_code);
     if (response == responses_.end())
     {
-      logger::info << "Unknown response " << command_code << std::endl;
+      logger::info() << "Unknown response " << command_code << std::endl;
       return;
     }
     (*(response->second))(time_read, echo_back, status, stream);

--- a/include/scip2/response/parameters.h
+++ b/include/scip2/response/parameters.h
@@ -23,6 +23,7 @@
 #include <map>
 
 #include <scip2/response/abstract.h>
+#include <scip2/logger.h>
 
 namespace scip2
 {
@@ -51,7 +52,7 @@ public:
     {
       if (cb_)
         cb_(time_read, echo_back, status, params);
-      std::cout << echo_back << " errored with " << status << std::endl;
+      logger::error << echo_back << " errored with " << status << std::endl;
       return;
     }
     std::string line;
@@ -62,13 +63,13 @@ public:
       const auto delm = std::find(line.begin(), line.end(), ':');
       if (delm == line.end())
       {
-        std::cout << "Parameter decode error" << std::endl;
+        logger::error << "Parameter decode error" << std::endl;
         return;
       }
       const auto end = std::find(line.begin(), line.end(), ';');
       if (end == line.end())
       {
-        std::cout << "Parameter decode error" << std::endl;
+        logger::error << "Parameter decode error" << std::endl;
         return;
       }
       const uint8_t checksum = line.back();
@@ -79,7 +80,7 @@ public:
       }
       if ((sum & 0x3F) + 0x30 != checksum)
       {
-        std::cerr << "Checksum mismatch; parameters dropped" << std::endl;
+        logger::error << "Checksum mismatch; parameters dropped" << std::endl;
         return;
       }
       const std::string key(line.begin(), delm);

--- a/include/scip2/response/parameters.h
+++ b/include/scip2/response/parameters.h
@@ -52,7 +52,7 @@ public:
     {
       if (cb_)
         cb_(time_read, echo_back, status, params);
-      logger::error << echo_back << " errored with " << status << std::endl;
+      logger::error() << echo_back << " errored with " << status << std::endl;
       return;
     }
     std::string line;
@@ -63,13 +63,13 @@ public:
       const auto delm = std::find(line.begin(), line.end(), ':');
       if (delm == line.end())
       {
-        logger::error << "Parameter decode error" << std::endl;
+        logger::error() << "Parameter decode error" << std::endl;
         return;
       }
       const auto end = std::find(line.begin(), line.end(), ';');
       if (end == line.end())
       {
-        logger::error << "Parameter decode error" << std::endl;
+        logger::error() << "Parameter decode error" << std::endl;
         return;
       }
       const uint8_t checksum = line.back();
@@ -80,7 +80,7 @@ public:
       }
       if ((sum & 0x3F) + 0x30 != checksum)
       {
-        logger::error << "Checksum mismatch; parameters dropped" << std::endl;
+        logger::error() << "Checksum mismatch; parameters dropped" << std::endl;
         return;
       }
       const std::string key(line.begin(), delm);

--- a/include/scip2/response/stream.h
+++ b/include/scip2/response/stream.h
@@ -25,6 +25,7 @@
 
 #include <scip2/decode.h>
 #include <scip2/response/abstract.h>
+#include <scip2/logger.h>
 
 namespace scip2
 {
@@ -71,20 +72,20 @@ public:
     {
       if (cb_)
         cb_(time_read, echo_back, status, scan);
-      std::cout << echo_back << " errored with " << status << std::endl;
+      logger::error << echo_back << " errored with " << status << std::endl;
       return false;
     }
     std::string stamp;
     if (!std::getline(stream, stamp))
     {
-      std::cerr << "Failed to get timestamp" << std::endl;
+      logger::error << "Failed to get timestamp" << std::endl;
       return false;
     }
     const uint8_t checksum = stamp.back();
     stamp.pop_back();  // remove checksum
     if (stamp.size() < 4)
     {
-      std::cerr << "Wrong timestamp format" << std::endl;
+      logger::error << "Wrong timestamp format" << std::endl;
       return false;
     }
 
@@ -93,7 +94,7 @@ public:
     scan.timestamp_ = *it;
     if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
     {
-      std::cerr << "Checksum mismatch" << std::endl;
+      logger::error << "Checksum mismatch" << std::endl;
       return false;
     }
     return true;
@@ -133,7 +134,7 @@ public:
       line.pop_back();  // remove checksum
       if (line.size() < 3)
       {
-        std::cerr << "Wrong stream format" << std::endl;
+        logger::error << "Wrong stream format" << std::endl;
         return;
       }
       auto dec = Decoder<3>(line, remain);
@@ -145,8 +146,8 @@ public:
       remain = it.getRemain();
       if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
       {
-        std::cerr << "Checksum mismatch; scan dropped" << std::endl
-                  << line << std::endl;
+        logger::error << "Checksum mismatch; scan dropped" << std::endl
+                      << line << std::endl;
         return;
       }
     }
@@ -185,7 +186,7 @@ public:
       line.pop_back();  // remove checksum
       if (line.size() < 3)
       {
-        std::cerr << "Wrong stream format" << std::endl;
+        logger::error << "Wrong stream format" << std::endl;
         return;
       }
       auto dec = Decoder<6>(line, remain);
@@ -198,8 +199,8 @@ public:
       remain = it.getRemain();
       if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
       {
-        std::cerr << "Checksum mismatch; scan dropped" << std::endl
-                  << line << std::endl;
+        logger::error << "Checksum mismatch; scan dropped" << std::endl
+                      << line << std::endl;
         return;
       }
     }

--- a/include/scip2/response/stream.h
+++ b/include/scip2/response/stream.h
@@ -72,20 +72,20 @@ public:
     {
       if (cb_)
         cb_(time_read, echo_back, status, scan);
-      logger::error << echo_back << " errored with " << status << std::endl;
+      logger::error() << echo_back << " errored with " << status << std::endl;
       return false;
     }
     std::string stamp;
     if (!std::getline(stream, stamp))
     {
-      logger::error << "Failed to get timestamp" << std::endl;
+      logger::error() << "Failed to get timestamp" << std::endl;
       return false;
     }
     const uint8_t checksum = stamp.back();
     stamp.pop_back();  // remove checksum
     if (stamp.size() < 4)
     {
-      logger::error << "Wrong timestamp format" << std::endl;
+      logger::error() << "Wrong timestamp format" << std::endl;
       return false;
     }
 
@@ -94,7 +94,7 @@ public:
     scan.timestamp_ = *it;
     if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
     {
-      logger::error << "Checksum mismatch" << std::endl;
+      logger::error() << "Checksum mismatch" << std::endl;
       return false;
     }
     return true;
@@ -134,7 +134,7 @@ public:
       line.pop_back();  // remove checksum
       if (line.size() < 3)
       {
-        logger::error << "Wrong stream format" << std::endl;
+        logger::error() << "Wrong stream format" << std::endl;
         return;
       }
       auto dec = Decoder<3>(line, remain);
@@ -146,8 +146,8 @@ public:
       remain = it.getRemain();
       if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
       {
-        logger::error << "Checksum mismatch; scan dropped" << std::endl
-                      << line << std::endl;
+        logger::error() << "Checksum mismatch; scan dropped" << std::endl
+                        << line << std::endl;
         return;
       }
     }
@@ -186,7 +186,7 @@ public:
       line.pop_back();  // remove checksum
       if (line.size() < 3)
       {
-        logger::error << "Wrong stream format" << std::endl;
+        logger::error() << "Wrong stream format" << std::endl;
         return;
       }
       auto dec = Decoder<6>(line, remain);
@@ -199,8 +199,8 @@ public:
       remain = it.getRemain();
       if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
       {
-        logger::error << "Checksum mismatch; scan dropped" << std::endl
-                      << line << std::endl;
+        logger::error() << "Checksum mismatch; scan dropped" << std::endl
+                        << line << std::endl;
         return;
       }
     }

--- a/include/scip2/response/time_sync.h
+++ b/include/scip2/response/time_sync.h
@@ -23,6 +23,7 @@
 #include <map>
 
 #include <scip2/response/abstract.h>
+#include <scip2/logger.h>
 
 namespace scip2
 {
@@ -65,7 +66,7 @@ public:
     {
       if (cb_)
         cb_(time_read, echo_back, status, timestamp);
-      std::cout << echo_back << " errored with " << status << std::endl;
+      logger::error << echo_back << " errored with " << status << std::endl;
       return;
     }
     if (echo_back[2] == '1')
@@ -73,14 +74,14 @@ public:
       std::string stamp;
       if (!std::getline(stream, stamp))
       {
-        std::cerr << "Failed to get timestamp" << std::endl;
+        logger::error << "Failed to get timestamp" << std::endl;
         return;
       }
       const uint8_t checksum = stamp.back();
       stamp.pop_back();  // remove checksum
       if (stamp.size() < 4)
       {
-        std::cerr << "Wrong timestamp format" << std::endl;
+        logger::error << "Wrong timestamp format" << std::endl;
         return;
       }
 
@@ -89,7 +90,7 @@ public:
       timestamp.timestamp_ = *it;
       if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
       {
-        std::cerr << "Checksum mismatch" << std::endl;
+        logger::error << "Checksum mismatch" << std::endl;
         return;
       }
     }

--- a/include/scip2/response/time_sync.h
+++ b/include/scip2/response/time_sync.h
@@ -66,7 +66,7 @@ public:
     {
       if (cb_)
         cb_(time_read, echo_back, status, timestamp);
-      logger::error << echo_back << " errored with " << status << std::endl;
+      logger::error() << echo_back << " errored with " << status << std::endl;
       return;
     }
     if (echo_back[2] == '1')
@@ -74,14 +74,14 @@ public:
       std::string stamp;
       if (!std::getline(stream, stamp))
       {
-        logger::error << "Failed to get timestamp" << std::endl;
+        logger::error() << "Failed to get timestamp" << std::endl;
         return;
       }
       const uint8_t checksum = stamp.back();
       stamp.pop_back();  // remove checksum
       if (stamp.size() < 4)
       {
-        logger::error << "Wrong timestamp format" << std::endl;
+        logger::error() << "Wrong timestamp format" << std::endl;
         return;
       }
 
@@ -90,7 +90,7 @@ public:
       timestamp.timestamp_ = *it;
       if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
       {
-        logger::error << "Checksum mismatch" << std::endl;
+        logger::error() << "Checksum mismatch" << std::endl;
         return;
       }
     }

--- a/src/ros_logger.cpp
+++ b/src/ros_logger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The urg_stamped Authors
+ * Copyright 2019 The urg_stamped Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ros_logger.cpp
+++ b/src/ros_logger.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 The urg_stamped Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <ros/ros.h>
+
+#include <scip2/logger.h>
+
+namespace urg_stamped
+{
+namespace
+{
+class ROSOutStreamBuffer : public std::stringbuf
+{
+public:
+  enum Type
+  {
+    LOG_DEBUG,
+    LOG_INFO,
+    LOG_WARN,
+    LOG_ERROR,
+    LOG_FATAL,
+  };
+  Type type_;
+
+  explicit ROSOutStreamBuffer(Type type)
+    : type_(type)
+  {
+  }
+  virtual int sync()
+  {
+    switch (type_)
+    {
+      case LOG_DEBUG:
+        ROS_DEBUG("%s", str().c_str());
+        break;
+      case LOG_INFO:
+        ROS_INFO("%s", str().c_str());
+        break;
+      case LOG_WARN:
+        ROS_WARN("%s", str().c_str());
+        break;
+      case LOG_ERROR:
+        ROS_ERROR("%s", str().c_str());
+        break;
+      case LOG_FATAL:
+        ROS_FATAL("%s", str().c_str());
+        break;
+    }
+    str("");
+    return 0;
+  }
+};
+
+ROSOutStreamBuffer debug_buf(ROSOutStreamBuffer::LOG_DEBUG);
+ROSOutStreamBuffer info_buf(ROSOutStreamBuffer::LOG_INFO);
+ROSOutStreamBuffer warn_buf(ROSOutStreamBuffer::LOG_WARN);
+ROSOutStreamBuffer error_buf(ROSOutStreamBuffer::LOG_ERROR);
+ROSOutStreamBuffer fatal_buf(ROSOutStreamBuffer::LOG_FATAL);
+std::ostream debug_logger(&debug_buf);
+std::ostream info_logger(&info_buf);
+std::ostream warn_logger(&warn_buf);
+std::ostream error_logger(&error_buf);
+std::ostream fatal_logger(&fatal_buf);
+}  // namespace
+
+void setROSLogger()
+{
+  scip2::logger::setDebugLogger(&debug_logger);
+  scip2::logger::setInfoLogger(&info_logger);
+  scip2::logger::setWarnLogger(&warn_logger);
+  scip2::logger::setErrorLogger(&error_logger);
+  scip2::logger::setFatalLogger(&fatal_logger);
+}
+}  // namespace urg_stamped

--- a/src/scip2/logger.cpp
+++ b/src/scip2/logger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The urg_stamped Authors
+ * Copyright 2019 The urg_stamped Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scip2/logger.cpp
+++ b/src/scip2/logger.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 The urg_stamped Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <scip2/logger.h>
+
+namespace scip2
+{
+namespace logger
+{
+namespace
+{
+class DefaultStreamBuffer : public std::stringbuf
+{
+private:
+  bool active_;
+  std::ostream *raw_;
+  std::string type_;
+
+public:
+  DefaultStreamBuffer(std::ostream *raw, const char *type)
+    : raw_(raw)
+    , type_(type)
+  {
+  }
+  virtual int sync()
+  {
+    if (raw_)
+    {
+      *raw_ << "[" << type_ << "] " << str();
+    }
+    str("");
+    return 0;
+  }
+};
+
+DefaultStreamBuffer debug_buf(&std::cout, "DEBUG");
+DefaultStreamBuffer info_buf(&std::cout, " INFO");
+DefaultStreamBuffer warn_buf(&std::cout, " WARN");
+DefaultStreamBuffer error_buf(&std::cerr, "ERROR");
+DefaultStreamBuffer fatal_buf(&std::cerr, "FATAL");
+}  // namespace
+
+std::ostream debug(&debug_buf);
+std::ostream info(&info_buf);
+std::ostream warn(&warn_buf);
+std::ostream error(&error_buf);
+std::ostream fatal(&fatal_buf);
+}  // namespace logger
+}  // namespace scip2

--- a/src/scip2/logger.cpp
+++ b/src/scip2/logger.cpp
@@ -55,12 +55,60 @@ DefaultStreamBuffer info_buf(&std::cout, " INFO");
 DefaultStreamBuffer warn_buf(&std::cout, " WARN");
 DefaultStreamBuffer error_buf(&std::cerr, "ERROR");
 DefaultStreamBuffer fatal_buf(&std::cerr, "FATAL");
+
+std::ostream default_debug(&debug_buf);
+std::ostream default_info(&info_buf);
+std::ostream default_warn(&warn_buf);
+std::ostream default_error(&error_buf);
+std::ostream default_fatal(&fatal_buf);
+
+std::ostream *current_debug(&default_debug);
+std::ostream *current_info(&default_info);
+std::ostream *current_warn(&default_warn);
+std::ostream *current_error(&default_error);
+std::ostream *current_fatal(&default_fatal);
 }  // namespace
 
-std::ostream debug(&debug_buf);
-std::ostream info(&info_buf);
-std::ostream warn(&warn_buf);
-std::ostream error(&error_buf);
-std::ostream fatal(&fatal_buf);
+void setDebugLogger(std::ostream *l)
+{
+  current_debug = l;
+}
+void setInfoLogger(std::ostream *l)
+{
+  current_info = l;
+}
+void setWarnLogger(std::ostream *l)
+{
+  current_warn = l;
+}
+void setErrorLogger(std::ostream *l)
+{
+  current_error = l;
+}
+void setFatalLogger(std::ostream *l)
+{
+  current_fatal = l;
+}
+
+std::ostream &debug()
+{
+  return *current_debug;
+}
+std::ostream &info()
+{
+  return *current_info;
+}
+std::ostream &warn()
+{
+  return *current_warn;
+}
+std::ostream &error()
+{
+  return *current_error;
+}
+std::ostream &fatal()
+{
+  return *current_fatal;
+}
 }  // namespace logger
 }  // namespace scip2

--- a/src/urg_stamped.cpp
+++ b/src/urg_stamped.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The urg_stamped Authors
+ * Copyright 2018-2019 The urg_stamped Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/urg_stamped.cpp
+++ b/src/urg_stamped.cpp
@@ -34,6 +34,7 @@
 #include <first_order_filter.h>
 #include <timestamp_moving_average.h>
 #include <timestamp_outlier_remover.h>
+#include <ros_logger.h>
 
 class UrgStampedNode
 {
@@ -509,6 +510,8 @@ public:
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "urg_stamped");
+  urg_stamped::setROSLogger();
+
   UrgStampedNode node;
   node.spin();
 

--- a/src/urg_stamped.cpp
+++ b/src/urg_stamped.cpp
@@ -396,7 +396,7 @@ protected:
   void delayEstimation(const ros::TimerEvent &event = ros::TimerEvent())
   {
     timer_sync_.stop();
-    ROS_INFO("Starting communication delay estimation");
+    ROS_DEBUG("Starting communication delay estimation");
     scip_->sendCommand("QT");
     timer_try_tm_ = nh_.createTimer(
         ros::Duration(0.05),


### PR DESCRIPTION
- all debug output is handled as ROS logger output
  - scip2 library part kept independent from ROS
- change continuously appearing message level to debug

```
[DEBUG] [1563769617.890775175]: Starting communication delay estimation
[DEBUG] [1563769617.899682817]: Scan data stopped
[DEBUG] [1563769617.941861709]: Scan data stopped
[DEBUG] [1563769617.942522650]: delay: 0.000355, device timestamp: 1017353, device time origin: 1563768600.585908
[DEBUG] [1563769617.944247720]: on scan delay: 0.001199, device timestamp: 1017355, device time origin: 1563768600.589047, gain: 1.000000
[DEBUG] [1563769617.971319573]: Size of the received scan data is wrong (expected: 1081, received: 540); refreshing
[DEBUG] [1563769619.099827366]: on scan delay (0.022267) is larger than expected; skipping
[DEBUG] [1563769619.121443106]: Size of the received scan data is wrong (expected: 1081, received: 540); refreshing
[FATAL] [1563769621.274479902]: Watchdog timeout
```