### PR TITLE
Add timestamp jump detector to Walltime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_timestamp_outlier_remover test/src/test_timestamp_outlier_remover.cpp)
   target_link_libraries(test_timestamp_outlier_remover ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-  catkin_add_gtest(test_walltime test/src/test_walltime.cpp)
+  catkin_add_gtest(test_walltime test/src/test_walltime.cpp src/scip2/logger.cpp)
   target_link_libraries(test_walltime ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 endif()
 

--- a/include/scip2/walltime.h
+++ b/include/scip2/walltime.h
@@ -42,12 +42,13 @@ public:
 
     if (detectDeviceTimeJump(time_device))
     {
-      logger::warn() << "Device time jumped." << std::endl;
       if (walltime_device_base_ >= (1 << DEVICE_TIMESTAMP_BITS))
       {
         time_device_prev_ = (1 << DEVICE_TIMESTAMP_BITS) - time_device;
         return walltime_device_base_ - time_device_prev_;
       }
+      logger::warn() << "Device time jumped. prev: " << time_device_prev_
+                     << ", current: " << time_device << std::endl;
     }
 
     if (time_device < middle_bits_ &&

--- a/include/scip2/walltime.h
+++ b/include/scip2/walltime.h
@@ -17,7 +17,7 @@
 #ifndef SCIP2_WALLTIME_H
 #define SCIP2_WALLTIME_H
 
-#include <string>
+#include <scip2/logger.h>
 
 namespace scip2
 {
@@ -38,9 +38,20 @@ public:
       initialized_ = true;
     }
 
-    if (time_device < (1 << DEVICE_TIMESTAMP_BITS) / 2 &&
-        (1 << DEVICE_TIMESTAMP_BITS) / 2 < time_device_prev_)
+    const uint32_t middle_bits = (1 << DEVICE_TIMESTAMP_BITS) / 2;
+
+    if (time_device_prev_ < middle_bits &&
+        middle_bits < time_device &&
+        time_device - time_device_prev_ > middle_bits)
+    {
+      logger::warn() << "Device time jumped." << std::endl;
+    }
+    if (time_device < middle_bits &&
+        middle_bits < time_device_prev_)
+    {
       walltime_device_base_ += 1 << DEVICE_TIMESTAMP_BITS;
+    }
+
     time_device_prev_ = time_device;
 
     return walltime_device_base_ + time_device;

--- a/include/scip2/walltime.h
+++ b/include/scip2/walltime.h
@@ -45,7 +45,10 @@ public:
         time_device - time_device_prev_ > middle_bits)
     {
       logger::warn() << "Device time jumped." << std::endl;
+      time_device_prev_ = (1 << DEVICE_TIMESTAMP_BITS) - time_device;
+      return walltime_device_base_ - time_device_prev_;
     }
+
     if (time_device < middle_bits &&
         middle_bits < time_device_prev_)
     {

--- a/include/scip2/walltime.h
+++ b/include/scip2/walltime.h
@@ -40,7 +40,7 @@ public:
       initialized_ = true;
     }
 
-    if (detectDeviceTimeJump(time_device))
+    if (detectDeviceTimeUnderflow(time_device))
     {
       if (walltime_device_base_ >= (1 << DEVICE_TIMESTAMP_BITS))
       {
@@ -62,7 +62,7 @@ public:
     return walltime_device_base_ + time_device;
   }
 
-  bool detectDeviceTimeJump(const uint32_t& time_device)
+  bool detectDeviceTimeUnderflow(const uint32_t& time_device)
   {
     return (time_device_prev_ < middle_bits_ &&
             middle_bits_ < time_device &&

--- a/test/src/test_walltime.cpp
+++ b/test/src/test_walltime.cpp
@@ -36,6 +36,27 @@ TEST(WalltimeTest, testTimestampOverflow)
   }
 }
 
+TEST(WalltimeTest, testDeviceTimeBitsBoundary)
+{
+  scip2::Walltime<24> walltime;
+
+  uint64_t device_time = (1 << 24) - 1;
+  uint32_t device_timestamp = device_time & 0xFFFFFF;
+  ASSERT_EQ(walltime.update(device_timestamp), device_time);
+
+  device_time = 0;
+  device_timestamp = device_time & 0xFFFFFF;
+  ASSERT_EQ(walltime.update(device_timestamp), (1 << 24) + device_time);
+
+  device_time = (1 << 24) - 1;
+  device_timestamp = device_time & 0xFFFFFF;
+  ASSERT_EQ(walltime.update(device_timestamp), device_time);
+
+  device_time = 0;
+  device_timestamp = device_time & 0xFFFFFF;
+  ASSERT_EQ(walltime.update(device_timestamp), (1 << 24) + device_time);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/test/src/test_walltime.cpp
+++ b/test/src/test_walltime.cpp
@@ -36,7 +36,7 @@ TEST(WalltimeTest, testTimestampOverflow)
   }
 }
 
-TEST(WalltimeTest, testDeviceTimeBitsBoundary)
+TEST(WalltimeTest, testDeviceTimeBoundary)
 {
   scip2::Walltime<24> walltime;
 


### PR DESCRIPTION
close #64 

## PR summary
This PR adds a device timestamp jump detector. If the input stamp is largely jumped, the detector regards it as jumped backwards beyond the timestamp boundary (device timestamp is 24 bit).