### PR TITLE
Fix prerelease test

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   prerelease:
     if: ${{ startsWith(github.head_ref, 'release-') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Pre-release test script is currently not working on Ubuntu 20.04.