### PR TITLE
Remove doubled QT command request

### DIFF
--- a/src/urg_stamped.cpp
+++ b/src/urg_stamped.cpp
@@ -457,10 +457,6 @@ void UrgStampedNode::retryTM(const ros::TimerEvent& event)
       break;
     case DelayEstimState::ESTIMATION_STARTING:
       ROS_DEBUG("Entering the time synchronization mode");
-      // The sensor sometimes doesn't stop scan
-      // even if successful QT response was returned.
-      // Send the QT command again to avoid it.
-      scip_->sendCommand("QT");
       scip_->sendCommand("TM0");
       break;
     case DelayEstimState::ESTIMATING:


### PR DESCRIPTION
If the data is not stopped by QT command, QT command will be resent:
https://github.com/seqsense/urg_stamped/blob/6a2c81693e42147aa7f6b019ae7addbbda2cd3e9/src/urg_stamped.cpp#L129-L140
(`delay_estim_state_ = DelayEstimState::STOPPING_SCAN`)
on next `retryTM` timer event. (0.1s interval)