### PR TITLE
Gracefully stop connection

### DIFF
--- a/include/scip2/connection.h
+++ b/include/scip2/connection.h
@@ -198,6 +198,7 @@ public:
   }
   void stop()
   {
+    socket_.close();
     io_.stop();
   }
   void send(const std::string& data, CallbackSend cb = CallbackSend())

--- a/src/urg_stamped.cpp
+++ b/src/urg_stamped.cpp
@@ -696,5 +696,6 @@ void UrgStampedNode::spin()
   delay_estim_state_ = DelayEstimState::EXITING;
   scip_->sendCommand("QT");
   device_->stop();
+  thread.join();
 }
 }  // namespace urg_stamped


### PR DESCRIPTION
Asio worker thread was not joined and callback could be remained after destruction of the class.

Fix https://github.com/seqsense/urg_stamped/issues/52