### PR TITLE
Fix parsing parameter containing semicolon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(test_device_time_origin ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
   catkin_add_gtest(test_first_order_filter test/src/test_first_order_filter.cpp)
+  catkin_add_gtest(test_param test/src/test_param.cpp)
 
   catkin_add_gtest(test_timestamp_moving_average test/src/test_timestamp_moving_average.cpp)
   target_link_libraries(test_timestamp_moving_average ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/include/scip2/param.h
+++ b/include/scip2/param.h
@@ -21,17 +21,17 @@
 
 namespace scip2
 {
-struct DecodedParam
+struct ParsedParam
 {
-  bool decoded;
+  bool parsed;
   bool checksum_matched;
   std::string key;
   std::string value;
 };
 
-static DecodedParam decodeParamLine(const std::string& line)
+static ParsedParam parseParamLine(const std::string& line)
 {
-  DecodedParam ret;
+  ParsedParam ret;
 
   const auto delm = std::find(line.begin(), line.end(), ':');
   if (delm == line.end())
@@ -43,7 +43,7 @@ static DecodedParam decodeParamLine(const std::string& line)
   {
     return ret;
   }
-  ret.decoded = true;
+  ret.parsed = true;
   ret.key = std::string(line.begin(), delm);
   ret.value = std::string(delm + 1, end);
 

--- a/include/scip2/param.h
+++ b/include/scip2/param.h
@@ -18,6 +18,7 @@
 #define SCIP2_PARAM_H
 
 #include <string>
+#include <algorithm>
 
 namespace scip2
 {

--- a/include/scip2/param.h
+++ b/include/scip2/param.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 The urg_stamped Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SCIP2_PARAM_H
+#define SCIP2_PARAM_H
+
+#include <string>
+
+namespace scip2
+{
+struct DecodedParam
+{
+  bool decoded;
+  bool checksum_matched;
+  std::string key;
+  std::string value;
+};
+
+static DecodedParam decodeParamLine(const std::string& line)
+{
+  DecodedParam ret;
+
+  const auto delm = std::find(line.begin(), line.end(), ':');
+  if (delm == line.end())
+  {
+    return ret;
+  }
+  const auto end = std::find(line.begin(), line.end(), ';');
+  if (end == line.end())
+  {
+    return ret;
+  }
+  ret.decoded = true;
+  ret.key = std::string(line.begin(), delm);
+  ret.value = std::string(delm + 1, end);
+
+  const uint8_t checksum = line.back();
+  uint8_t sum = 0;
+  for (auto it = line.begin(); it != end; ++it)
+  {
+    sum += *it;
+  }
+  if ((sum & 0x3F) + 0x30 == checksum)
+  {
+    ret.checksum_matched = true;
+  }
+  return ret;
+}
+}  // namespace scip2
+
+#endif  // SCIP2_PARAM_H

--- a/include/scip2/response/parameters.h
+++ b/include/scip2/response/parameters.h
@@ -61,8 +61,8 @@ public:
       if (line.size() == 0)
         break;
 
-      const DecodedParam p = decodeParamLine(line);
-      if (!p.decoded)
+      const ParsedParam p = parseParamLine(line);
+      if (!p.parsed)
       {
         logger::error() << "Parameter decode error" << std::endl;
         return;

--- a/include/scip2/response/parameters.h
+++ b/include/scip2/response/parameters.h
@@ -64,12 +64,12 @@ public:
       const ParsedParam p = parseParamLine(line);
       if (!p.parsed)
       {
-        logger::error() << "Parameter decode error" << std::endl;
+        logger::error() << "Parameter decode error: " << p.error << std::endl;
         return;
       }
       if (!p.checksum_matched)
       {
-        logger::error() << "Checksum mismatch; parameters dropped" << std::endl;
+        logger::error() << "Checksum mismatch; parameters dropped: " << p.error << std::endl;
         return;
       }
       params[p.key] = p.value;

--- a/include/scip2/response/parameters.h
+++ b/include/scip2/response/parameters.h
@@ -24,6 +24,7 @@
 
 #include <scip2/response/abstract.h>
 #include <scip2/logger.h>
+#include <scip2/param.h>
 
 namespace scip2
 {
@@ -59,32 +60,19 @@ public:
     {
       if (line.size() == 0)
         break;
-      const auto delm = std::find(line.begin(), line.end(), ':');
-      if (delm == line.end())
+
+      const DecodedParam p = decodeParamLine(line);
+      if (!p.decoded)
       {
         logger::error() << "Parameter decode error" << std::endl;
         return;
       }
-      const auto end = std::find(line.begin(), line.end(), ';');
-      if (end == line.end())
-      {
-        logger::error() << "Parameter decode error" << std::endl;
-        return;
-      }
-      const uint8_t checksum = line.back();
-      uint8_t sum = 0;
-      for (auto it = line.begin(); it != end; ++it)
-      {
-        sum += *it;
-      }
-      if ((sum & 0x3F) + 0x30 != checksum)
+      if (!p.checksum_matched)
       {
         logger::error() << "Checksum mismatch; parameters dropped" << std::endl;
         return;
       }
-      const std::string key(line.begin(), delm);
-      const std::string value(delm + 1, end);
-      params[key] = value;
+      params[p.key] = p.value;
     }
     if (cb_)
       cb_(time_read, echo_back, status, params);

--- a/test/src/test_param.cpp
+++ b/test/src/test_param.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 The urg_stamped Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <scip2/param.h>
+
+TEST(ParseParamLine, parsed)
+{
+  // Checksum example shown in SCIP2.0 Specification
+  const std::string line("PROT:SCIP 2.0;N");
+  const scip2::ParsedParam p = scip2::parseParamLine(line);
+  ASSERT_EQ(true, p.parsed);
+  ASSERT_EQ(true, p.checksum_matched);
+  ASSERT_EQ("PROT", p.key);
+  ASSERT_EQ("SCIP 2.0", p.value);
+}
+
+TEST(ParseParamLine, noDelimiter)
+{
+  const std::string line("PROT+SCIP 2.0;N");
+  const scip2::ParsedParam p = scip2::parseParamLine(line);
+  ASSERT_EQ(false, p.parsed);
+}
+
+TEST(ParseParamLine, checksumMismatch)
+{
+  const std::string line("PROT:SCIP 2.0;X");
+  const scip2::ParsedParam p = scip2::parseParamLine(line);
+  ASSERT_EQ(true, p.parsed);
+  ASSERT_EQ(false, p.checksum_matched);
+  ASSERT_EQ("PROT", p.key);
+  ASSERT_EQ("SCIP 2.0", p.value);
+}
+
+TEST(ParseParamLine, containsSemicolon)
+{
+  const std::string line("TIME:j;o[;H");
+  const scip2::ParsedParam p = scip2::parseParamLine(line);
+  ASSERT_EQ(true, p.parsed);
+  ASSERT_EQ(true, p.checksum_matched);
+  ASSERT_EQ("PROT", p.key);
+  ASSERT_EQ("SCIP 2.0", p.value);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/test/src/test_param.cpp
+++ b/test/src/test_param.cpp
@@ -25,10 +25,17 @@ TEST(ParseParamLine, parsed)
   // Checksum example shown in SCIP2.0 Specification
   const std::string line("PROT:SCIP 2.0;N");
   const scip2::ParsedParam p = scip2::parseParamLine(line);
-  ASSERT_EQ(true, p.parsed);
+  ASSERT_EQ(true, p.parsed) << p.error;
   ASSERT_EQ(true, p.checksum_matched);
   ASSERT_EQ("PROT", p.key);
   ASSERT_EQ("SCIP 2.0", p.value);
+}
+
+TEST(ParseParamLine, shortLine)
+{
+  const std::string line(";");
+  const scip2::ParsedParam p = scip2::parseParamLine(line);
+  ASSERT_EQ(false, p.parsed);
 }
 
 TEST(ParseParamLine, noDelimiter)
@@ -38,11 +45,17 @@ TEST(ParseParamLine, noDelimiter)
   ASSERT_EQ(false, p.parsed);
 }
 
+TEST(ParseParamLine, noChecksumDelimiter)
+{
+  const std::string line("PROT:SCIP 2.0");
+  const scip2::ParsedParam p = scip2::parseParamLine(line);
+  ASSERT_EQ(false, p.parsed);
+}
 TEST(ParseParamLine, checksumMismatch)
 {
   const std::string line("PROT:SCIP 2.0;X");
   const scip2::ParsedParam p = scip2::parseParamLine(line);
-  ASSERT_EQ(true, p.parsed);
+  ASSERT_EQ(true, p.parsed) << p.error;
   ASSERT_EQ(false, p.checksum_matched);
   ASSERT_EQ("PROT", p.key);
   ASSERT_EQ("SCIP 2.0", p.value);
@@ -52,10 +65,10 @@ TEST(ParseParamLine, containsSemicolon)
 {
   const std::string line("TIME:j;o[;H");
   const scip2::ParsedParam p = scip2::parseParamLine(line);
-  ASSERT_EQ(true, p.parsed);
+  ASSERT_EQ(true, p.parsed) << p.error;
   ASSERT_EQ(true, p.checksum_matched);
-  ASSERT_EQ("PROT", p.key);
-  ASSERT_EQ("SCIP 2.0", p.value);
+  ASSERT_EQ("TIME", p.key);
+  ASSERT_EQ("j;o[", p.value);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Parameter values returned from sensor on `II`, `PP`, `VV` command may contain semicolon. It was parsed as a delimiter before checksum and failed to verify checksum.
e.g. `TIME` field of `II` reponse