### PR TITLE
Reboot on reset error only if requested reset

### DIFF
--- a/include/urg_stamped/urg_stamped.h
+++ b/include/urg_stamped/urg_stamped.h
@@ -118,6 +118,8 @@ protected:
   int tm_try_max_;
   int tm_try_count_;
 
+  bool cmd_resetting_;
+
   void cbM(
       const boost::posix_time::ptime& time_read,
       const std::string& echo_back,


### PR DESCRIPTION
Due to the II command during measurement for sensor time estimation, the data stream may be split by II response.
Split data stream may randomly start with RS and be detected as a reset failure.

This commit avoids reboot on reset failure when reset is not requested.