### PR TITLE
Add option to disable on-scan time sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Topics and major parameters are designed to be compatible with [urg_node](http:/
 - **sync_interval_min** (double): minimum interval to try observing sensor internal timestamp in seconds
 - **sync_interval_max** (double): maximum interval to try observing sensor internal timestamp in seconds
 - **delay_estim_interval** (double): communication delay estimation interval in seconds (dropping 2 or 3 scans during delay estimation)
+- **disable_on_scan_sync** (bool): disable on-scan time synchronization for models like UST-05LX
 
 ## Known Limitations
 

--- a/include/urg_stamped/urg_stamped.h
+++ b/include/urg_stamped/urg_stamped.h
@@ -98,7 +98,9 @@ protected:
   size_t tm_iter_num_;
   size_t tm_median_window_;
   bool estimated_communication_delay_init_;
+  bool device_time_origin_init_;
   double communication_delay_filter_alpha_;
+  ros::Time tm_start_time_;
 
   boost::posix_time::ptime time_ii_request;
   std::vector<ros::Duration> on_scan_communication_delays_;

--- a/include/urg_stamped/urg_stamped.h
+++ b/include/urg_stamped/urg_stamped.h
@@ -61,6 +61,7 @@ protected:
 
   bool publish_intensity_;
   bool failed_;
+  bool disable_on_scan_sync_;
 
   enum class DelayEstimState
   {
@@ -167,6 +168,7 @@ protected:
   void timeSync(const ros::TimerEvent& event = ros::TimerEvent());
   void delayEstimation(const ros::TimerEvent& event = ros::TimerEvent());
   void retryTM(const ros::TimerEvent& event = ros::TimerEvent());
+  void updateOrigin(const ros::Time& now, const ros::Time& origin, const ros::Time& time_at_device_timestamp);
 
   void errorCountIncrement(const std::string& status = "");
 

--- a/include/urg_stamped/urg_stamped.h
+++ b/include/urg_stamped/urg_stamped.h
@@ -42,6 +42,24 @@
 
 namespace urg_stamped
 {
+class DeviceOriginAt
+{
+public:
+  ros::Time origin_;
+  ros::Time at_;
+
+  inline DeviceOriginAt(const ros::Time origin, const ros::Time at)
+    : origin_(origin)
+    , at_(at)
+  {
+  }
+
+  inline bool operator<(const DeviceOriginAt& b) const
+  {
+    return origin_ < b.origin_;
+  }
+};
+
 class UrgStampedNode
 {
 protected:
@@ -75,7 +93,7 @@ protected:
   DelayEstimState delay_estim_state_;
   boost::posix_time::ptime time_tm_request;
   std::list<ros::Duration> communication_delays_;
-  std::list<ros::Time> device_time_origins_;
+  std::list<DeviceOriginAt> device_time_origins_;
   ros::Duration estimated_communication_delay_;
   size_t tm_iter_num_;
   size_t tm_median_window_;

--- a/src/urg_stamped.cpp
+++ b/src/urg_stamped.cpp
@@ -163,6 +163,10 @@ void UrgStampedNode::cbTM(
     {
       scip2::logger::debug() << "Entered the time synchronization mode" << std::endl;
       delay_estim_state_ = DelayEstimState::ESTIMATING;
+
+      tm_start_time_ = ros::Time::now();
+      device_time_origins_.clear();
+
       scip_->sendCommand(
           "TM1",
           boost::bind(&UrgStampedNode::cbTMSend, this, boost::arg<1>()));
@@ -184,54 +188,65 @@ void UrgStampedNode::cbTM(
       if (communication_delays_.size() > tm_median_window_)
         communication_delays_.pop_front();
 
-      const auto origin = device_time_origin::estimator::estimateOriginByAverage(
-          time_tm_request, time_read, walltime_device);
-      device_time_origins_.push_back(DeviceOriginAt(origin, ros::Time::fromBoost(time_read) - delay * 0.5));
-      if (device_time_origins_.size() > tm_median_window_)
-        device_time_origins_.pop_front();
-
       if (communication_delays_.size() >= tm_iter_num_)
       {
+        const size_t i_med = communication_delays_.size() / 2;
         std::vector<ros::Duration> delays(communication_delays_.begin(), communication_delays_.end());
-        std::vector<DeviceOriginAt> origins(device_time_origins_.begin(), device_time_origins_.end());
         std::sort(delays.begin(), delays.end());
-        std::sort(origins.begin(), origins.end());
 
         if (!estimated_communication_delay_init_)
         {
-          estimated_communication_delay_ = delays[tm_iter_num_ / 2];
-          device_time_origin_ = device_time_origin::DriftedTime(origins[tm_iter_num_ / 2].origin_, 1.0);
+          estimated_communication_delay_ = delays[i_med];
+          estimated_communication_delay_init_ = true;
         }
         else
         {
           estimated_communication_delay_ =
               estimated_communication_delay_ * (1.0 - communication_delay_filter_alpha_) +
-              delays[tm_iter_num_ / 2] * communication_delay_filter_alpha_;
-          if (disable_on_scan_sync_)
-          {
-            const auto now = ros::Time::fromBoost(time_read);
-            updateOrigin(now, origins[tm_iter_num_ / 2].origin_, origins[tm_iter_num_ / 2].at_);
-            scip2::logger::debug()
-                << "device time origin: " << device_time_origin_.origin_
-                << ", gain: " << device_time_origin_.gain_ << std::endl;
-          }
+              delays[i_med] * communication_delay_filter_alpha_;
         }
-        estimated_communication_delay_init_ = true;
         scip2::logger::debug()
             << "delay: "
             << std::setprecision(6) << std::fixed << estimated_communication_delay_.toSec()
             << ", device timestamp: " << walltime_device
-            << ", device time origin: " << origins[tm_iter_num_ / 2].origin_.toSec()
             << std::endl;
-        scip_->sendCommand("TM2");
       }
-      else
+
+      const auto origin = device_time_origin::estimator::estimateOriginByAverage(
+          time_tm_request, time_read, walltime_device);
+      device_time_origins_.emplace_back(origin, ros::Time::fromBoost(time_read) - delay * 0.5);
+
+      if (device_time_origins_.size() >= tm_iter_num_ && estimated_communication_delay_init_)
       {
-        ros::Duration(0.005).sleep();
-        scip_->sendCommand(
-            "TM1",
-            boost::bind(&UrgStampedNode::cbTMSend, this, boost::arg<1>()));
+        std::vector<DeviceOriginAt> origins(device_time_origins_.begin(), device_time_origins_.end());
+        std::sort(origins.begin(), origins.end());
+
+        const size_t i_med = device_time_origins_.size() / 2;
+        if (!device_time_origin_init_)
+        {
+          device_time_origin_ = device_time_origin::DriftedTime(origins[i_med].origin_, 1.0);
+          device_time_origin_init_ = true;
+        }
+
+        if (disable_on_scan_sync_)
+        {
+          const auto now = ros::Time::fromBoost(time_read);
+          updateOrigin(now, origins[i_med].origin_, origins[i_med].at_);
+          scip2::logger::debug()
+              << "device time origin: " << device_time_origin_.origin_
+              << ", gain: " << device_time_origin_.gain_
+              << ", origin: " << origins[i_med].origin_
+              << ", at: " << origins[i_med].at_
+              << std::endl;
+        }
+        scip_->sendCommand("TM2");
+        break;
       }
+
+      ros::Duration(0.005).sleep();
+      scip_->sendCommand(
+          "TM1",
+          boost::bind(&UrgStampedNode::cbTMSend, this, boost::arg<1>()));
       break;
     }
     case '2':
@@ -245,7 +260,12 @@ void UrgStampedNode::cbTM(
       timestamp_outlier_removal_.reset();
       timestamp_moving_average_.reset();
       t0_ = ros::Time();
-      scip2::logger::debug() << "Leaving the time synchronization mode" << std::endl;
+      scip2::logger::debug()
+          << std::setprecision(6) << std::fixed
+          << "Leaving the time synchronization mode (took "
+          << (ros::Time::now() - tm_start_time_).toSec()
+          << ")"
+          << std::endl;
       tm_success_ = true;
       break;
     }
@@ -737,6 +757,7 @@ UrgStampedNode::UrgStampedNode()
   , tm_iter_num_(5)
   , tm_median_window_(35)
   , estimated_communication_delay_init_(false)
+  , device_time_origin_init_(false)
   , communication_delay_filter_alpha_(0.3)
   , last_sync_time_(0)
   , timestamp_lpf_(20)


### PR DESCRIPTION
On UST-05LX, on-scan time sync doesn't work since II command never responded within 2ms.
This PR add an option to disable on-scan time sync and only use ordinal time sync method using TM command.