### PR TITLE
Fix handling of multiple responses in one read

### DIFF
--- a/include/scip2/connection.h
+++ b/include/scip2/connection.h
@@ -22,6 +22,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/bind/bind.hpp>
+#include <boost/function.hpp>
 
 #include <scip2/logger.h>
 

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -43,24 +43,26 @@ protected:
     std::istream stream(&buf);
     const auto pos = stream.tellg();
 
-    std::string echo_back;
-    if (!std::getline(stream, echo_back))
+    if (stream.eof())
     {
       return;
     }
+    std::string echo_back;
+    std::getline(stream, echo_back);
     if (echo_back == "")
     {
       logger::debug() << "Empty response echo back" << std::endl;
       return;
     }
 
-    std::string status;
-    if (!std::getline(stream, status))
+    if (stream.eof())
     {
-      // Re-read from beginning on the next callback
+      // Re-read from the beginning on the next callback
       stream.seekg(pos);
       return;
     }
+    std::string status;
+    std::getline(stream, status);
     if (status == "")
     {
       logger::debug() << "Empty response status" << std::endl;

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -41,32 +41,33 @@ protected:
       const boost::posix_time::ptime& time_read)
   {
     std::istream stream(&buf);
-    while (true)
-    {
-      std::string echo_back;
-      if (!std::getline(stream, echo_back))
-      {
-        return;
-      }
-      if (echo_back == "")
-      {
-        continue;
-      }
-      std::string status;
-      if (!std::getline(stream, status))
-      {
-        logger::error() << "Failed to get status" << std::endl;
-        return;
-      }
-      if (status == "")
-      {
-        logger::debug() << "Ignoring response without status" << std::endl;
-        continue;
-      }
-      status.pop_back();  // remove checksum
+    const auto pos = stream.tellg();
 
-      response_processor_(time_read, echo_back, status, stream);
+    std::string echo_back;
+    if (!std::getline(stream, echo_back))
+    {
+      return;
     }
+    if (echo_back == "")
+    {
+      logger::debug() << "Empty response echo back" << std::endl;
+      return;
+    }
+
+    std::string status;
+    if (!std::getline(stream, status))
+    {
+      stream.seekg(pos);
+      return;
+    }
+    if (status == "")
+    {
+      logger::debug() << "Empty response status" << std::endl;
+      return;
+    }
+    status.pop_back();  // remove checksum
+
+    response_processor_(time_read, echo_back, status, stream);
   }
 
 public:

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -43,7 +43,11 @@ protected:
     std::istream stream(&buf);
 
     std::string echo_back;
-    std::getline(stream, echo_back);
+    if (!std::getline(stream, echo_back))
+    {
+      logger::error() << "Failed to get echo back" << std::endl;
+      return;
+    }
     if (echo_back == "")
     {
       logger::debug() << "Empty response echo back " << std::endl;
@@ -51,7 +55,11 @@ protected:
     }
 
     std::string status;
-    std::getline(stream, status);
+    if (!std::getline(stream, status))
+    {
+      logger::error() << "Failed to get status" << std::endl;
+      return;
+    }
     if (status == "")
     {
       logger::debug() << "Empty response status" << std::endl;

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -58,6 +58,11 @@ protected:
         logger::error() << "Failed to get status" << std::endl;
         return;
       }
+      if (status == "")
+      {
+        logger::debug() << "Ignoring response without status" << std::endl;
+        continue;
+      }
       status.pop_back();  // remove checksum
 
       response_processor_(time_read, echo_back, status, stream);

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -28,11 +28,6 @@
 #include <scip2/response.h>
 #include <scip2/logger.h>
 
-namespace
-{
-
-}  // namespace
-
 namespace scip2
 {
 class Protocol

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -41,25 +41,26 @@ protected:
       const boost::posix_time::ptime& time_read)
   {
     std::istream stream(&buf);
-    std::string echo_back;
-    if (!std::getline(stream, echo_back))
+    while (true)
     {
-      logger::error() << "Failed to get echo back" << std::endl;
-      return;
-    }
-    std::string status;
-    if (!std::getline(stream, status))
-    {
-      logger::error() << "Failed to get status" << std::endl;
-      return;
-    }
-    status.pop_back();  // remove checksum
+      std::string echo_back;
+      if (!std::getline(stream, echo_back))
+      {
+        return;
+      }
+      if (echo_back == "")
+      {
+        continue;
+      }
+      std::string status;
+      if (!std::getline(stream, status))
+      {
+        logger::error() << "Failed to get status" << std::endl;
+        return;
+      }
+      status.pop_back();  // remove checksum
 
-    response_processor_(time_read, echo_back, status, stream);
-
-    std::string line;
-    while (std::getline(stream, line))
-    {
+      response_processor_(time_read, echo_back, status, stream);
     }
   }
 

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -28,6 +28,11 @@
 #include <scip2/response.h>
 #include <scip2/logger.h>
 
+namespace
+{
+
+}  // namespace
+
 namespace scip2
 {
 class Protocol
@@ -41,26 +46,15 @@ protected:
       const boost::posix_time::ptime& time_read)
   {
     std::istream stream(&buf);
-    const auto pos = stream.tellg();
 
-    if (stream.eof())
-    {
-      return;
-    }
     std::string echo_back;
     std::getline(stream, echo_back);
     if (echo_back == "")
     {
-      logger::debug() << "Empty response echo back" << std::endl;
+      logger::debug() << "Empty response echo back " << std::endl;
       return;
     }
 
-    if (stream.eof())
-    {
-      // Re-read from the beginning on the next callback
-      stream.seekg(pos);
-      return;
-    }
     std::string status;
     std::getline(stream, status);
     if (status == "")

--- a/include/scip2/protocol.h
+++ b/include/scip2/protocol.h
@@ -57,6 +57,7 @@ protected:
     std::string status;
     if (!std::getline(stream, status))
     {
+      // Re-read from beginning on the next callback
       stream.seekg(pos);
       return;
     }

--- a/include/scip2/response.h
+++ b/include/scip2/response.h
@@ -67,10 +67,7 @@ public:
     if (response == responses_.end())
     {
       logger::debug() << "Unknown response " << command_code << std::endl;
-      std::string line;
-      while (std::getline(stream, line) && line.size() > 0)
-      {
-      }
+      readUntilEnd(stream);
       return;
     }
     (*(response->second))(time_read, echo_back, status, stream);

--- a/include/scip2/response.h
+++ b/include/scip2/response.h
@@ -67,6 +67,10 @@ public:
     if (response == responses_.end())
     {
       logger::debug() << "Unknown response " << command_code << std::endl;
+      std::string line;
+      while (std::getline(stream, line) && line.size() > 0)
+      {
+      }
       return;
     }
     (*(response->second))(time_read, echo_back, status, stream);

--- a/include/scip2/response/abstract.h
+++ b/include/scip2/response/abstract.h
@@ -36,6 +36,14 @@ public:
       std::istream&) = 0;
 };
 
+inline void readUntilEnd(std::istream& stream)
+{
+  std::string line;
+  while (std::getline(stream, line) && line.size() > 0)
+  {
+  }
+}
+
 }  // namespace scip2
 
 #endif  // SCIP2_RESPONSE_ABSTRACT_H

--- a/include/scip2/response/quit.h
+++ b/include/scip2/response/quit.h
@@ -48,7 +48,10 @@ public:
       std::istream& stream)
   {
     if (cb_)
+    {
       cb_(time_read, echo_back, status);
+    }
+    readUntilEnd(stream);
   }
   void registerCallback(Callback cb)
   {

--- a/include/scip2/response/reboot.h
+++ b/include/scip2/response/reboot.h
@@ -48,7 +48,10 @@ public:
       std::istream& stream)
   {
     if (cb_)
+    {
       cb_(time_read, echo_back, status);
+    }
+    readUntilEnd(stream);
   }
   void registerCallback(Callback cb)
   {

--- a/include/scip2/response/reset.h
+++ b/include/scip2/response/reset.h
@@ -48,7 +48,10 @@ public:
       std::istream& stream)
   {
     if (cb_)
+    {
       cb_(time_read, echo_back, status);
+    }
+    readUntilEnd(stream);
   }
   void registerCallback(Callback cb)
   {
@@ -79,7 +82,10 @@ public:
       std::istream& stream)
   {
     if (cb_)
+    {
       cb_(time_read, echo_back, status);
+    }
+    readUntilEnd(stream);
   }
   void registerCallback(Callback cb)
   {

--- a/include/scip2/response/stream.h
+++ b/include/scip2/response/stream.h
@@ -115,7 +115,10 @@ public:
     if (!readTimestamp(time_read, echo_back, status, stream, scan))
     {
       if (cb_)
+      {
         cb_(time_read, echo_back, status, scan);
+      }
+      readUntilEnd(stream);
       return;
     }
     scan.ranges_.reserve(512);
@@ -149,7 +152,9 @@ public:
       }
     }
     if (cb_)
+    {
       cb_(time_read, echo_back, status, scan);
+    }
   }
 };
 
@@ -206,7 +211,9 @@ public:
       }
     }
     if (cb_)
+    {
       cb_(time_read, echo_back, status, scan);
+    }
   }
 };
 

--- a/include/scip2/response/time_sync.h
+++ b/include/scip2/response/time_sync.h
@@ -65,7 +65,10 @@ public:
     if (status != "00")
     {
       if (cb_)
+      {
         cb_(time_read, echo_back, status, timestamp);
+      }
+      readUntilEnd(stream);
       return;
     }
     if (echo_back[2] == '1')
@@ -74,6 +77,7 @@ public:
       if (!std::getline(stream, stamp))
       {
         logger::error() << "Failed to get timestamp" << std::endl;
+        readUntilEnd(stream);
         return;
       }
       const uint8_t checksum = stamp.back();
@@ -81,6 +85,7 @@ public:
       if (stamp.size() < 4)
       {
         logger::error() << "Wrong timestamp format" << std::endl;
+        readUntilEnd(stream);
         return;
       }
 
@@ -90,11 +95,15 @@ public:
       if ((dec.getChecksum() & 0x3F) + 0x30 != checksum)
       {
         logger::error() << "Checksum mismatch" << std::endl;
+        readUntilEnd(stream);
         return;
       }
     }
     if (cb_)
+    {
       cb_(time_read, echo_back, status, timestamp);
+    }
+    readUntilEnd(stream);
   }
   void registerCallback(Callback cb)
   {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,12 @@ target_link_libraries(test_timestamp_moving_average ${catkin_LIBRARIES} ${Boost_
 catkin_add_gtest(test_timestamp_outlier_remover src/test_timestamp_outlier_remover.cpp)
 target_link_libraries(test_timestamp_outlier_remover ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+catkin_add_gtest(test_scip2
+  src/test_scip2.cpp
+  ../src/scip2/logger.cpp
+)
+target_link_libraries(test_scip2 ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 catkin_add_gtest(test_walltime src/test_walltime.cpp ../src/scip2/logger.cpp)
 target_link_libraries(test_walltime ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/test/src/test_scip2.cpp
+++ b/test/src/test_scip2.cpp
@@ -102,9 +102,6 @@ TEST(SCIP2, MultipleResponses)
   os << "\n\n";
   dev->feed(buf, now);
   ASSERT_EQ(2, num_receive);
-
-  dev->feed(buf, now);
-  ASSERT_EQ(2, num_receive);
 }
 
 int main(int argc, char** argv)

--- a/test/src/test_scip2.cpp
+++ b/test/src/test_scip2.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 The urg_stamped Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include <scip2/protocol.h>
+#include <scip2/connection.h>
+
+class ConnectionDummy : public scip2::Connection
+{
+public:
+  void spin() final
+  {
+  }
+  void stop() final
+  {
+  }
+  void send(const std::string&, CallbackSend = CallbackSend()) final
+  {
+  }
+  void startWatchdog(const boost::posix_time::time_duration&) final
+  {
+  }
+  void feed(const std::string& data, const boost::posix_time::ptime& time_read)
+  {
+    boost::asio::streambuf buf;
+    std::ostream os(&buf);
+    os << data;
+    receive(buf, time_read);
+  }
+};
+
+TEST(SCIP2, MultipleResponses)
+{
+  std::shared_ptr<ConnectionDummy> dev(new ConnectionDummy());
+  scip2::Protocol p(dev);
+
+  const auto now = boost::posix_time::microsec_clock::universal_time();
+  int num_receive = 0;
+
+  const auto cb =
+      [&num_receive, now](
+          const boost::posix_time::ptime& time_read,
+          const std::string& echo_back,
+          const std::string& status)
+  {
+    num_receive++;
+    EXPECT_EQ(now, time_read);
+  };
+  p.registerCallback<scip2::ResponseQT>(cb);
+
+  /*
+  Input data:
+
+  QT  // First QT command
+
+  FOO // Unknown command
+  BAR
+  QT  // This line must be ignored as a part of unknown command
+
+  QT  // Second QT command
+
+  */
+  dev->feed("QT\n\nFOO\nBAR\nQT\n\nQT\n\n", now);
+  ASSERT_EQ(2, num_receive);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/test/src/test_scip2.cpp
+++ b/test/src/test_scip2.cpp
@@ -64,22 +64,27 @@ TEST(SCIP2, MultipleResponses)
   {
     num_receive++;
     EXPECT_EQ(now, time_read);
+    EXPECT_EQ("00", status);
   };
   p.registerCallback<scip2::ResponseQT>(cb);
 
   /*
   Input data:
 
-  QT  // First QT command
+  QT  // First QT response
+  00P
 
-  FOO // Unknown command
+  FOO // Unknown response
   BAR
   QT  // This line must be ignored as a part of unknown command
 
-  QT  // Second QT command
+  QT  // This must be ignored as it doesn't have correct status line
+
+  QT  // Second QT response
+  00P
 
   */
-  dev->feed("QT\n\nFOO\nBAR\nQT\n\nQT\n\n", now);
+  dev->feed("QT\n00P\n\nFOO\nBAR\nQT\n\nQT\n\nQT\n00P\n\n", now);
   ASSERT_EQ(2, num_receive);
 }
 


### PR DESCRIPTION
`boost::asio::async_read_until` may return multiple blocks of data (separated by specified delimiter) when they are received shortly.
Current implementation dropped second and later blocks.


---

Found during #151 development