### PR TITLE
Include cstdint

### DIFF
--- a/include/scip2/connection.h
+++ b/include/scip2/connection.h
@@ -17,6 +17,7 @@
 #ifndef SCIP2_CONNECTION_H
 #define SCIP2_CONNECTION_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/include/scip2/decode.h
+++ b/include/scip2/decode.h
@@ -17,6 +17,7 @@
 #ifndef SCIP2_DECODE_H
 #define SCIP2_DECODE_H
 
+#include <cstdint>
 #include <string>
 
 namespace scip2

--- a/include/scip2/param.h
+++ b/include/scip2/param.h
@@ -17,6 +17,7 @@
 #ifndef SCIP2_PARAM_H
 #define SCIP2_PARAM_H
 
+#include <cstdint>
 #include <string>
 #include <algorithm>
 

--- a/include/scip2/response/stream.h
+++ b/include/scip2/response/stream.h
@@ -19,6 +19,7 @@
 
 #include <boost/asio.hpp>
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/include/scip2/response/time_sync.h
+++ b/include/scip2/response/time_sync.h
@@ -19,6 +19,7 @@
 
 #include <boost/asio.hpp>
 
+#include <cstdint>
 #include <string>
 #include <map>
 

--- a/include/scip2/walltime.h
+++ b/include/scip2/walltime.h
@@ -17,6 +17,8 @@
 #ifndef SCIP2_WALLTIME_H
 #define SCIP2_WALLTIME_H
 
+#include <cstdint>
+
 #include <scip2/logger.h>
 
 namespace scip2

--- a/include/urg_sim/encode.h
+++ b/include/urg_sim/encode.h
@@ -17,6 +17,7 @@
 #ifndef URG_SIM_ENCODE_H
 #define URG_SIM_ENCODE_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/urg_sim/urg_sim.h
+++ b/include/urg_sim/urg_sim.h
@@ -18,6 +18,7 @@
 #define URG_SIM_URG_SIM_H
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <map>

--- a/include/urg_stamped/device_time_origin.h
+++ b/include/urg_stamped/device_time_origin.h
@@ -19,6 +19,7 @@
 
 #include <ros/ros.h>
 
+#include <cstdint>
 #include <cmath>
 
 namespace urg_stamped

--- a/include/urg_stamped/urg_stamped.h
+++ b/include/urg_stamped/urg_stamped.h
@@ -25,6 +25,7 @@
 #include <boost/thread.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <list>
 #include <map>
 #include <random>

--- a/src/urg_sim/encode.cpp
+++ b/src/urg_sim/encode.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/urg_sim/urg_sim.cpp
+++ b/src/urg_sim/urg_sim.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstdint>
 #include <iostream>
 #include <mutex>
 #include <sstream>

--- a/src/urg_stamped.cpp
+++ b/src/urg_stamped.cpp
@@ -25,6 +25,7 @@
 #include <boost/thread.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <list>
 #include <map>
 #include <random>


### PR DESCRIPTION
Types like `uint32_t` requires `cstdint` include.