### PR TITLE
Fix stamp on initial state

### DIFF
--- a/include/urg_stamped/device_state_estimator.h
+++ b/include/urg_stamped/device_state_estimator.h
@@ -68,7 +68,7 @@ public:
   {
   }
 
-  inline ClockState(const ros::Time& origin, const double gain, const uint64_t stamp, bool initialized = true)
+  inline ClockState(const ros::Time& origin, const double gain, const uint64_t stamp, const bool initialized = true)
     : origin_(origin)
     , gain_(gain)
     , stamp_(stamp)

--- a/include/urg_stamped/device_state_estimator.h
+++ b/include/urg_stamped/device_state_estimator.h
@@ -68,11 +68,11 @@ public:
   {
   }
 
-  inline ClockState(const ros::Time& origin, const double gain, const uint64_t stamp)
+  inline ClockState(const ros::Time& origin, const double gain, const uint64_t stamp, bool initialized = true)
     : origin_(origin)
     , gain_(gain)
     , stamp_(stamp)
-    , initialized_(true)
+    , initialized_(initialized)
   {
   }
 

--- a/src/device_state_estimator.cpp
+++ b/src/device_state_estimator.cpp
@@ -125,13 +125,15 @@ bool Estimator::finishSync()
 
   if (recent_clocks_.size() <= 1)
   {
+    // Initialized=false since clock gain is not yet estimated
+    clock_ = ClockState(clock.origin_, 1, min_delay->device_wall_stamp_, false);
+
     scip2::logger::debug()
         << "initial origin: " << clock.origin_
         << ", delay: " << min_delay->delay_
         << ", delay sigma: " << comm_delay_.sigma_
         << ", device timestamp: " << min_delay->device_wall_stamp_
         << std::endl;
-
     return true;
   }
 

--- a/test/src/test_device_state_estimator.cpp
+++ b/test/src/test_device_state_estimator.cpp
@@ -155,6 +155,42 @@ TEST(DeviceStateEstimator, ClockGain)
   }
 }
 
+TEST(DeviceStateEstimatorUTM, InitialClockState)
+{
+  EstimatorUTM est(ros::Duration(0.1));
+  const double t0 = 100;
+
+  est.startSync();
+  for (double t = 10; t < 10.2; t += 0.0101)
+  {
+    est.pushSyncSample(ros::Time(t0 + t), ros::Time(t0 + t + 0.00001), t * 1000);
+  }
+  est.finishSync();
+
+  ASSERT_NEAR(
+      t0 + 31.0000,
+      est.getClockState().stampToTime(31000).toSec(),
+      0.0001);
+}
+
+TEST(DeviceStateEstimatorUST, InitialClockState)
+{
+  EstimatorUST est(ros::Duration(0.1));
+  const double t0 = 100;
+
+  est.startSync();
+  for (double t = 10; t < 10.2; t += 0.0101)
+  {
+    est.pushSyncSample(ros::Time(t0 + t), ros::Time(t0 + t + 0.00001), t * 1000);
+  }
+  est.finishSync();
+
+  ASSERT_NEAR(
+      t0 + 31.0000,
+      est.getClockState().stampToTime(31000).toSec(),
+      0.0001);
+}
+
 TEST(DeviceStateEstimatorUTM, PushScanSampleRaw)
 {
   EstimatorUTM est(ros::Duration(0.1));

--- a/test/src/test_device_state_estimator.cpp
+++ b/test/src/test_device_state_estimator.cpp
@@ -171,6 +171,10 @@ TEST(DeviceStateEstimatorUTM, InitialClockState)
       t0 + 31.0000,
       est.getClockState().stampToTime(31000).toSec(),
       0.0001);
+  ASSERT_NEAR(
+      t0 + 51.0000,
+      est.getClockState().stampToTime(51000).toSec(),
+      0.0001);
 }
 
 TEST(DeviceStateEstimatorUST, InitialClockState)
@@ -188,6 +192,10 @@ TEST(DeviceStateEstimatorUST, InitialClockState)
   ASSERT_NEAR(
       t0 + 31.0000,
       est.getClockState().stampToTime(31000).toSec(),
+      0.0001);
+  ASSERT_NEAR(
+      t0 + 51.0000,
+      est.getClockState().stampToTime(51000).toSec(),
       0.0001);
 }
 


### PR DESCRIPTION
Before the second clock origin estimation, timestamp near the unix time epoch was published.
Fix to use naively calculated timestamp until clock gain is estimated.