### PR TITLE
Fix time validation

### DIFF
--- a/src/scan_estimator_ust.cpp
+++ b/src/scan_estimator_ust.cpp
@@ -117,7 +117,7 @@ std::pair<ros::Time, bool> ScanEstimatorUST::pushScanSample(const ros::Time& t_r
     }
     else
     {
-      if (scan_.origin_.isValid() && scan_.origin_ + ros::Duration(30) < t_recv)
+      if (!scan_.origin_.isZero() && scan_.origin_ + ros::Duration(30) < t_recv)
       {
         scan_.origin_ = t_stamp;
         scan_.interval_ = ideal_scan_interval_ * (1.0 / clock.gain_);

--- a/src/urg_stamped.cpp
+++ b/src/urg_stamped.cpp
@@ -73,7 +73,7 @@ void UrgStampedNode::cbM(
   const uint64_t walltime_device = walltime_.update(scan.timestamp_);
   const ros::Time time_read_ros = ros::Time::fromBoost(time_read);
 
-  if (next_sync_.isValid() && time_read_ros > next_sync_)
+  if (!next_sync_.isZero() && time_read_ros > next_sync_)
   {
     estimateSensorClock();
     next_sync_ += clock_estim_interval_;

--- a/test/src/sync_timing.cpp
+++ b/test/src/sync_timing.cpp
@@ -142,8 +142,8 @@ TEST_F(SyncTiming, NoConcurrentSync)
 
   ASSERT_NO_FATAL_FAILURE(spinFor(ros::Duration(5)));
 
-  ASSERT_TRUE(sync_start_time_["laser0"].isValid());
-  ASSERT_TRUE(sync_start_time_["laser1"].isValid());
+  ASSERT_TRUE(!sync_start_time_["laser0"].isZero());
+  ASSERT_TRUE(!sync_start_time_["laser1"].isZero());
 
   // Base interval is 1s
   const double diff = std::remainder(


### PR DESCRIPTION
`static ros::Time::isValid()` checks time source availability, not checking a time value.
Use `!ros::Time::isZero()` instead.