### PR TITLE
Fix periodic timestamp overflow by widening Timestamp field to uint64_t

### DIFF
--- a/include/scip2/response/time_sync.h
+++ b/include/scip2/response/time_sync.h
@@ -31,7 +31,7 @@ namespace scip2
 class Timestamp
 {
 public:
-  uint32_t timestamp_;
+  uint64_t timestamp_;
   bool is_wall_;
 
   Timestamp()


### PR DESCRIPTION
The microsecond `timestamp_` field in `scip2::Timestamp` was stored as
`uint32_t`, which wraps after 2^32 µs (~72 min of device uptime). The wrap
corrupted timestamps and triggered spurious sensor restarts deterministically
across the whole fleet.

Widen `timestamp_` to `uint64_t` so the value no longer overflows in practice.